### PR TITLE
Carefully guard the parameters to build_where

### DIFF
--- a/lib/squint.rb
+++ b/lib/squint.rb
@@ -30,7 +30,8 @@ module Squint
             if arg[key].is_a?(Hash) && HASH_DATA_COLUMNS[key]
               memo << klass.squint_hash_field_reln(key => arg[key])
             else
-              save_args << {  key => arg[key] }
+              save_args[0] ||= {}
+              save_args[0][key] = arg[key]
             end
           end
         elsif arg.present?
@@ -40,6 +41,8 @@ module Squint
       end
       if ActiveRecord::VERSION::STRING > '5'
         reln = ActiveRecord::Relation::WhereClause.new(reln, [])
+        save_args << [] if save_args.size == 1
+      else
         save_args << [] if save_args.size == 1
       end
       reln += super(*save_args) unless save_args.empty?

--- a/test/squint_test.rb
+++ b/test/squint_test.rb
@@ -120,4 +120,17 @@ class SquintTest < ActiveSupport::TestCase
       assert_equal 1, reln.count
     end
   end
+
+  #
+  # Make sure that build_where isn't passed more than 2 parameters
+  # There was a bug...
+  #
+  test 'with find by lotsa things' do
+    assert_nothing_raised do
+      Post.find_by(id: 1, title: 'sumpthin',
+                   body: 'sumpthin else',
+                   created_at: '2015-01-01')
+    end
+  end
+
 end


### PR DESCRIPTION
- find_by calls build_where under the hood, and
  squint was previously sending too many parameters
  over to build_where when there were more than 2
  keys in the hash of conditions