### PR TITLE
Fix HASH_DATA_COLUMNS to not be shared between ActiveRecord models

### DIFF
--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -11,4 +11,6 @@ class Post < ActiveRecord::Base
   store_attribute :storext_hstore_attributes, :hstore_friend_count, Integer, default: 0
   store_attribute :storext_hstore_attributes, :hstore_is_awesome, Integer, default: false
   store_attribute :storext_hstore_attributes, :hstore_is_present, Integer, default: nil
+
+  store_attribute :settings, :zip_code, String, default: '90210'
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ActiveRecord::Base
+  include Storext.model
+  include Squint
+
+  store_attribute :settings, :zip_code, String, default: '90210'
+end

--- a/test/dummy/db/migrate/20200318185942_create_users.rb
+++ b/test/dummy/db/migrate/20200318185942_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration
+  def change
+    create_table :users do |t|
+      t.hstore :settings
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/migrate/20200318185943_add_settings_to_posts.rb
+++ b/test/dummy/db/migrate/20200318185943_add_settings_to_posts.rb
@@ -1,0 +1,7 @@
+class AddSettingsToPosts < ActiveRecord::Migration
+  def change
+    change_table :posts do |t|
+      t.jsonb :settings
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170512185941) do
+ActiveRecord::Schema.define(version: 20200318185943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,11 +25,17 @@ ActiveRecord::Schema.define(version: 20170512185941) do
     t.hstore   "storext_hstore_attributes"
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
+    t.jsonb    "settings"
+    t.index ["properties"], name: "index_posts_on_properties", using: :gin
+    t.index ["request_info"], name: "index_posts_on_request_info", using: :gin
+    t.index ["storext_hstore_attributes"], name: "index_posts_on_storext_hstore_attributes", using: :gin
+    t.index ["storext_jsonb_attributes"], name: "index_posts_on_storext_jsonb_attributes", using: :gin
   end
 
-  add_index "posts", ["properties"], name: "index_posts_on_properties", using: :gin
-  add_index "posts", ["request_info"], name: "index_posts_on_request_info", using: :gin
-  add_index "posts", ["storext_hstore_attributes"], name: "index_posts_on_storext_hstore_attributes", using: :gin
-  add_index "posts", ["storext_jsonb_attributes"], name: "index_posts_on_storext_jsonb_attributes", using: :gin
+  create_table "users", force: :cascade do |t|
+    t.hstore   "settings"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/test/dummy/user.rb
+++ b/test/dummy/user.rb
@@ -1,0 +1,6 @@
+class User < ActiveRecord::Base
+  include Storext.model
+  include Squint
+
+  store_attribute :settings, :zip_code, String, default: '90210'
+end

--- a/test/squint_test.rb
+++ b/test/squint_test.rb
@@ -132,4 +132,9 @@ class SquintTest < ActiveSupport::TestCase
                    created_at: '2015-01-01')
     end
   end
+
+  test 'HASH_DATA_COLUMNS is not shared between models' do
+    assert_equal('hstore', User::HASH_DATA_COLUMNS[:settings])
+    assert_equal('jsonb' , Post::HASH_DATA_COLUMNS[:settings])
+  end
 end


### PR DESCRIPTION
The constant `HASH_DATA_COLUMNS` is being defined on the concern and not the class extending the concern. This causes problems if you happen to have mixed jsonb/hstore columns with the same name across tables.

Consider this failing test scenario in master:
```ruby
class User < ActiveRecord::Base
  include Storext.model
  include Squint

  store_attribute :settings, :zip_code, String, default: '90210' # this is hstore
end

class Post < ActiveRecord::Base
  include Storext.model
  include Squint
  # ... skip a bunch of unrelated settings ...
  store_attribute :settings, :zip_code, String, default: '90210' # this is jsonb
end

test 'HASH_DATA_COLUMNS is not shared between models' do 
  assert_equal('hstore', User::HASH_DATA_COLUMNS[:settings])
  assert_equal('jsonb' , Post::HASH_DATA_COLUMNS[:settings])
 end
```

Test Output without the fix:
```
Failure:
SquintTest#test_HASH_DATA_COLUMNS_is_not_shared_between_models [/Users/jamescook/open_source/squint/test/squint_test.rb:137]:
Expected: "hstore"
  Actual: "jsonb"
```

Also, I think this is the true source of https://github.com/ProctorU/squint/pull/19